### PR TITLE
feat: implement creation  POST endpoint

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,8 +1,8 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, status 
 from typing import List
 
 # Importiamo il nostro nuovo modello dal file models.py
-from models import Creation
+from models import Creation, CreationCreate
 
 # 1. Importa il middleware CORS
 from fastapi.middleware.cors import CORSMiddleware
@@ -46,3 +46,20 @@ def get_creations():
     Restituisce la lista di tutte le creazioni artistiche.
     """
     return db_creations
+
+@app.post("/api/creations", response_model=Creation, status_code=status.HTTP_201_CREATED)
+def create_creation(creation_data: CreationCreate):
+    """
+    Crea una nuova opera d'arte e la aggiunge al database (finto).
+    """
+    # 1. Calcola il nuovo ID (in un DB reale, questo è automatico)
+    new_id = max(c.id for c in db_creations) + 1 if db_creations else 1
+
+    # 2. Crea un oggetto Creation completo, unendo l'ID generato ai dati ricevuti
+    new_creation = Creation(id=new_id, **creation_data.model_dump())
+
+    # 3. Aggiungi il nuovo oggetto alla nostra lista in memoria
+    db_creations.append(new_creation)
+
+    # 4. Restituisci l'oggetto appena creato
+    return new_creation

--- a/models.py
+++ b/models.py
@@ -2,8 +2,18 @@
 from pydantic import BaseModel
 from typing import Dict
 
+
+# Questo modello definisce i dati necessari per CREARE una Creation.
+# Nota l'assenza del campo 'id'.
+class CreationCreate(BaseModel):
+    name: str
+    author: str
+    params: Dict
+
 # Pydantic usa le classi per definire la "forma" dei dati.
 # Ereditando da BaseModel, otteniamo tutta la magia della validazione.
+# Questo modello rappresenta i dati che RESTITUIAMO al client.
+# Contiene tutti i campi, incluso l'id generato dal server.
 class Creation(BaseModel):
     """
     Rappresenta una singola creazione artistica generativa.


### PR DESCRIPTION
Questa PR introduce la funzionalità per creare nuove opere d'arte.

**Cambiamenti implementati:**

**Backend (API):**
- Aggiunto un modello Pydantic `CreationCreate` per la validazione dei dati in ingresso.
- Creato un nuovo endpoint `POST /api/creations` che accetta i dati, genera un nuovo ID e salva la risorsa in memoria.
- L'endpoint restituisce uno status code `201 Created` in caso di successo.
